### PR TITLE
Forced flush option

### DIFF
--- a/applications/FluidDynamicsApplication/python_scripts/compute_drag_process.py
+++ b/applications/FluidDynamicsApplication/python_scripts/compute_drag_process.py
@@ -32,7 +32,8 @@ class ComputeDragProcess(KratosMultiphysics.Process):
                 "print_drag_to_screen"      : false,
                 "print_format"              : ".8f",
                 "write_drag_output_file"    : true,
-                "output_file_settings": {}
+                "output_file_settings": {},
+                "forced_flush_step_frequency" : -1
             }
             """)
 
@@ -55,6 +56,13 @@ class ComputeDragProcess(KratosMultiphysics.Process):
             raise Exception('No "model_part_name" was specified!')
         else:
             self.model_part = model[self.params["model_part_name"].GetString()]
+        
+        self.forced_flush_step_frequency = self.params["forced_flush_step_frequency"].GetInt()
+        # If write_buffer_size is set to default, change it for a large number
+        # so the forced_flush_step_frequency governs the flush.
+        if self.params["output_file_settings"].Has("write_buffer_size"):
+            if self.params["output_file_settings"]["write_buffer_size"].GetInt() < 0 and self.forced_flush_step_frequency > 0:
+                self.params["output_file_settings"]["write_buffer_size"].SetInt(10)
 
     def ExecuteInitialize(self):
 
@@ -101,6 +109,9 @@ class ComputeDragProcess(KratosMultiphysics.Process):
                 # in the file writer when restarting
                 if (self.write_drag_output_file):
                     self.output_file.write(str(current_time)+" "+format(drag_force[0],self.format)+" "+format(drag_force[1],self.format)+" "+format(drag_force[2],self.format)+"\n")
+
+                    if self.forced_flush_step_frequency > 0 and current_step % self.forced_flush_step_frequency == 0:
+                        self.output_file.flush()
 
     def ExecuteFinalize(self):
         if (self.write_drag_output_file):

--- a/kratos/python_scripts/line_output_process.py
+++ b/kratos/python_scripts/line_output_process.py
@@ -34,7 +34,8 @@ class LineOutputProcess(KratosMultiphysics.Process):
             "search_configuration" : "initial",
             "search_tolerance"  : 1e-6,
             "print_format"      : "",
-            "output_file_settings": {}
+            "output_file_settings": {},
+            "forced_flush_step_frequency" : -1
         }''')
 
         params.ValidateAndAssignDefaults(default_settings)

--- a/kratos/python_scripts/multiple_points_output_process.py
+++ b/kratos/python_scripts/multiple_points_output_process.py
@@ -33,7 +33,8 @@ class MultiplePointsOutputProcess(KratosMultiphysics.Process):
             "search_configuration" : "initial",
             "search_tolerance"  : 1e-6,
             "print_format"      : "",
-            "output_file_settings": {}
+            "output_file_settings": {},
+            "forced_flush_step_frequency" : -1
         }''')
 
         params.ValidateAndAssignDefaults(default_settings)

--- a/kratos/python_scripts/point_output_process.py
+++ b/kratos/python_scripts/point_output_process.py
@@ -150,6 +150,7 @@ class PointOutputProcess(KratosMultiphysics.Process):
 
     def ExecuteFinalize(self):
         for f in self.output_file:
+            f.flush()
             f.close()
 
     def __SearchPoint(self):


### PR DESCRIPTION
**Description**

In continuation with the idea posted in #7974.

Addition of the option to flush every certain number of time steps. The idea is to control the flush manually and be able to set its step frequency to a value different to 1. This could save some time in simulations with a large number of output files.

The feature was added to the compute_drag_process and point_output_process. Since line_output_process and multiple_point_output_process depend rely on point_output_process, the default values were updated so the option can be used also with them.

In case the parameter forced_flush_step_frequency is set, and write_buffer_size is set to its default value, the processes overwrite write_buffer_size and substitute it for a large number. Then, forced_flush_step_frequency governs the flush of the files and there is not any intermediate flush.

**Changelog**
- Added feature to point_output_process.
- Change default values in line_output_process and multiple_point_output_process.
- Added feature to compute_drag_process.
- Introduced a final flush when the simulation ends.